### PR TITLE
Fixed issue with Windows based OS and other minor stuff.

### DIFF
--- a/C-Plus-Plus-Labs/guest_secret_number/guest_secret_number.cpp
+++ b/C-Plus-Plus-Labs/guest_secret_number/guest_secret_number.cpp
@@ -6,7 +6,11 @@
 
 int main()
 {
+  #ifdef _WIN32
+  system("cls");
+  #else
   system("clear");
+  #endif
 
   // Variable declaration/initialization
   int inputNumber, secretNumber, min = 1, max = 100, attempts = 1;

--- a/C-Plus-Plus-Labs/guest_secret_number/guest_secret_number.cpp
+++ b/C-Plus-Plus-Labs/guest_secret_number/guest_secret_number.cpp
@@ -14,7 +14,7 @@ int main()
 
   // Get a random number between min and max values
   srand(time(NULL));
-  secretNumber = rand() % max + 1;
+  secretNumber = rand() % max + min;
 
   // Guest loop
   do


### PR DESCRIPTION
# Changes
* The random number generated was not taking into account the defined min value, instead was using a 1.
* There was an issue when running the program over windows based OS due to the use of the "clear" system call not being available in that platform. A build flag was added to switch between "cls" and "clear".